### PR TITLE
More edits.

### DIFF
--- a/draft-ietf-tls-wkech.txt
+++ b/draft-ietf-tls-wkech.txt
@@ -340,9 +340,6 @@ Internet-Draft           Well-Known URI for ECH                June 2024
 
         {
            "endpoints": [{
-               "alias": "cdn1.example.net",
-               "regeninterval": 108000
-           }, {
                "alias": "cdn2.example.com",
                "regeninterval": 108000
            }]
@@ -352,18 +349,24 @@ Internet-Draft           Well-Known URI for ECH                June 2024
 
    The JSON file at the well-known URI MUST contain an object with an
    "endpoints" key that contains an array of objects.  All other keys
-   MUST be ignored.
+   MUST be ignored.  The length of the list implies restrictions and
+   meaning to the content of the entries:
 
-   The endpoints array MUST be a homogeneous collection of objects,
-   where every entry is either a SerivceMode entry containing at least
-   one key from the JSON HTTP Origin Info registry (see IANA
-   Considerations section), or every entry is an AliasMode entry that
-   points to another DNS name that must be resolved.
+   o  An empty endpoints array corresponds to an HTTPS record with
+      inferred SvcPriority, the TargetName equal to ".", and no ECH
+      support.  This can can be useful as a simple way to make use of
+      the HTTPS RR type's HSTS behavior.
+   o  An endpoints array with one element can be either a ServiceMode
+      entry, containing at least one key from the JSON HTTP Origin Info
+      registry (see IANA Considerations (Section 9), below) or an
+      AliasMode entry that points to another DNS name that must be
+      resolved.
+   o  If the endpoints array has more than one element, every item MUST
+      be a ServiceMode entry.
 
-   An empty endpoint object corresponds to an HTTPS record with inferred
-   SvcPriority, TargetName=".", and no ECH support.  An empty record of
-   this kind can be useful as a simple way to make use of the HTTPS RR
-   type's HSTS behavior.
+   The intent of these restrictions is to reduce the chance of
+   misconfiguration by the ZF and to avoid introducing semantics not
+   defined by [RFC9460].
 
    The following keys are defined for both types of entries:
 
@@ -382,9 +385,6 @@ Internet-Draft           Well-Known URI for ECH                June 2024
       SvcPriority from the order of the endpoints array.
    o  params: A JSON Dictionary representing the SVCB SvcParams.  Each
       key in the dictionary is a string containing a registered
-      SvcParamKey name (e.g., "ipv6hint") or a SvcParamKey in generic
-      form (e.g., "key65528").
-
 
 
 
@@ -393,6 +393,9 @@ Farrell, et al.         Expires December 14, 2024               [Page 7]
 
 Internet-Draft           Well-Known URI for ECH                June 2024
 
+
+      SvcParamKey name (e.g., "ipv6hint") or a SvcParamKey in generic
+      form (e.g., "key65528").
 
       *  For single-valued SvcParams (e.g., "ech"), the value is a JSON
          String.  A JSON String is a sequence of Unicode codepoints,
@@ -405,9 +408,7 @@ Internet-Draft           Well-Known URI for ECH                June 2024
          Array of Strings.  Each String represents an octet sequence, as
          in the single-value case.
 
-   The following key is defined for AliasMode entries.  If this key is
-   present than any ech or port keys within the params key MUST be
-   ignored.
+   The following key is defined for AliasMode entries.
 
    o  alias: The value MUST be a DNS name that could be used as the
       TargetName of an HTTPS resource record.  This indicates that the
@@ -441,7 +442,6 @@ Internet-Draft           Well-Known URI for ECH                June 2024
    If the ZF is unable to convert the JSON into a DNS zone (e.g., due to
    an unrecognized SvcParamKey), or if the resulting zone fails
    validation checks, the ZF MUST NOT update the DNS.  Such failures
-   will not be directly visible to the client-facing server, so ZF
 
 
 
@@ -450,6 +450,7 @@ Farrell, et al.         Expires December 14, 2024               [Page 8]
 Internet-Draft           Well-Known URI for ECH                June 2024
 
 
+   will not be directly visible to the client-facing server, so ZF
    implementations will need to provide some form of reporting so that
    the situation can be resolved.  Note that this can lead to
    inconsistent behavior for a single origin served by multiple ZFs.
@@ -497,7 +498,6 @@ Internet-Draft           Well-Known URI for ECH                June 2024
 
    o  The bootstrap connection would not be able to use ECH, so it would
       reveal all the information that ECH seeks to protect.
-
 
 
 
@@ -586,16 +586,16 @@ Internet-Draft           Well-Known URI for ECH                June 2024
               (URIs)", RFC 8615, DOI 10.17487/RFC8615, May 2019,
               <https://www.rfc-editor.org/info/rfc8615>.
 
+   [RFC9460]  Schwartz, B., Bishop, M., and E. Nygren, "Service Binding
+              and Parameter Specification via the DNS (SVCB and HTTPS
+              Resource Records)", RFC 9460, DOI 10.17487/RFC9460,
+              November 2023, <https://www.rfc-editor.org/info/rfc9460>.
+
 10.2.  Informative References
 
    [ISOMORPHIC-DECODE]
               WHATWG, "WHATWG definition of Isomorphic Decode",
               <https://infra.spec.whatwg.org/#isomorphic-decode>.
-
-
-
-
-
 
 
 

--- a/draft-ietf-tls-wkech.txt
+++ b/draft-ietf-tls-wkech.txt
@@ -370,9 +370,9 @@ Internet-Draft           Well-Known URI for ECH                June 2024
       SHOULD be a ServiceMode entry, due to restrictions on the use of
       multiple AliasMode records (see , Section 2.4.2 [RFC9460]).
 
-   The intent of these restrictions is to reduce the chance of
-   misconfiguration by the ZF and to avoid introducing semantics not
-   defined by [RFC9460].
+   This format is designed to allow full use of the capabilities of
+   HTTPS records [RFC9460] in natural JSON while minimizing the risk of
+   invalid configurations.
 
    The following keys are defined for both types of entries:
 
@@ -384,8 +384,8 @@ Internet-Draft           Well-Known URI for ECH                June 2024
 
    o  target: The value is a string containing a fully qualified domain
       name, corresponding to the HTTPS record's TargetName.  The default
-      value is ".".  All labels in the name MUST contain only octets
-      from the ABNF set ALPHA / DIGIT / "-" / "_".
+      value is ".".
+
 
 
 

--- a/draft-ietf-tls-wkech.txt
+++ b/draft-ietf-tls-wkech.txt
@@ -74,7 +74,7 @@ Table of Contents
      3.2.  Split-mode, multi-CDN deplpoyment.  . . . . . . . . . . .   5
    4.  The origin-svcb well-known URI  . . . . . . . . . . . . . . .   6
    5.  The JSON structure for origin service binding info  . . . . .   6
-   6.  Zone Factory behaviour  . . . . . . . . . . . . . . . . . . .   8
+   6.  Zone Factory behaviour  . . . . . . . . . . . . . . . . . . .   9
    7.  Security Considerations . . . . . . . . . . . . . . . . . . .   9
    8.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  10
    9.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  10
@@ -310,15 +310,14 @@ Internet-Draft           Well-Known URI for ECH                June 2024
    [[ NOTE: JSON structure is a work in progress.]]
 
        {
+           "regeninterval": 3600,
            "endpoints": [{
-               "regeninterval": 3600,
                "priority": 1,
                "target": "cdn.example.",
                "params": {
                    "ech": "AD7+DQA65wAgAC..AA=="
                }
            }, {
-               "regeninterval": 3600,
                "priority": 1,
                "params": {
                    "port": 8413,
@@ -333,24 +332,34 @@ Internet-Draft           Well-Known URI for ECH                June 2024
 
 
 
+
 Farrell, et al.         Expires December 14, 2024               [Page 6]
 
 Internet-Draft           Well-Known URI for ECH                June 2024
 
 
         {
+           "regeninterval": 108000,
            "endpoints": [{
-               "alias": "cdn2.example.com",
-               "regeninterval": 108000
+               "alias": "cdn1.example.com",
            }]
          }
 
                     Figure 4: Sample JSON with aliasing
 
    The JSON file at the well-known URI MUST contain an object with an
-   "endpoints" key that contains an array of objects.  All other keys
-   MUST be ignored.  The length of the list implies restrictions and
-   meaning to the content of the entries:
+   two keys: "regeninterval", whose value is a number, and "endpoints"
+   whose value is an array of objects.  All other keys MUST be ignored.
+
+   The "regeninterval" must be a number greater than zero and specifies
+   the number of seconds between key generation actions at the origin,
+   i.e. a replacement ECHConfigList may be generated this often.  This
+   is used by the ZF to generate DNS TTL values and to determine when to
+   next poll the origin for updates.
+
+   The "endpoints" key is an array of objects.  The number of items in
+   the array implies restrictions and meaning to the content of the
+   items:
 
    o  An empty endpoints array means that all HTTPS records that the ZF
       has published for the origin should be deleted.
@@ -374,17 +383,8 @@ Internet-Draft           Well-Known URI for ECH                June 2024
    HTTPS records [RFC9460] in natural JSON while minimizing the risk of
    invalid configurations.
 
-   The following keys are defined for both types of entries:
-
-   o  regeninterval: the number of seconds between key generation
-      actions at the origin, i.e. a replacement ECHConfigList may be
-      generated this often.
-
    The following keys are defined for ServiceMode entries:
 
-   o  target: The value is a string containing a fully qualified domain
-      name, corresponding to the HTTPS record's TargetName.  The default
-      value is ".".
 
 
 
@@ -394,6 +394,9 @@ Farrell, et al.         Expires December 14, 2024               [Page 7]
 Internet-Draft           Well-Known URI for ECH                June 2024
 
 
+   o  target: The value is a string containing a fully qualified domain
+      name, corresponding to the HTTPS record's TargetName.  The default
+      value is ".".
    o  priority: The value is a positive integer corresponding to the
       SvcPriority.  If omitted, the ZF MAY infer numerically increasing
       SvcPriority from the order of the endpoints array.
@@ -435,13 +438,10 @@ Internet-Draft           Well-Known URI for ECH                June 2024
       maintenance burden of staying synchronized with the target's key
       rotations and configuration updates.
 
-6.  Zone Factory behaviour
 
-   If the ZF is unable to convert the JSON into a DNS zone (e.g., due to
-   an unrecognized SvcParamKey), or if the resulting zone fails
-   validation checks, the ZF MUST NOT update the DNS.  Such failures
-   will not be directly visible to the client-facing server, so ZF
-   implementations will need to provide some form of reporting so that
+
+
+
 
 
 
@@ -450,6 +450,13 @@ Farrell, et al.         Expires December 14, 2024               [Page 8]
 Internet-Draft           Well-Known URI for ECH                June 2024
 
 
+6.  Zone Factory behaviour
+
+   If the ZF is unable to convert the JSON into a DNS zone (e.g., due to
+   an unrecognized SvcParamKey), or if the resulting zone fails
+   validation checks, the ZF MUST NOT update the DNS.  Such failures
+   will not be directly visible to the client-facing server, so ZF
+   implementations will need to provide some form of reporting so that
    the situation can be resolved.  Note that this can lead to
    inconsistent behavior for a single origin served by multiple ZFs.
 
@@ -491,13 +498,6 @@ Internet-Draft           Well-Known URI for ECH                June 2024
 
    Although this configuration resource MAY be publicly accessible,
    general HTTP clients SHOULD NOT attempt to use this resource in lieu
-   of HTTPS records queries through their preferred DNS server for the
-   following reasons:
-
-   o  The bootstrap connection would not be able to use ECH, so it would
-      reveal all the information that ECH seeks to protect.
-
-
 
 
 
@@ -506,6 +506,11 @@ Farrell, et al.         Expires December 14, 2024               [Page 9]
 Internet-Draft           Well-Known URI for ECH                June 2024
 
 
+   of HTTPS records queries through their preferred DNS server for the
+   following reasons:
+
+   o  The bootstrap connection would not be able to use ECH, so it would
+      reveal all the information that ECH seeks to protect.
    o  The origin could serve the user with a uniquely identifying
       configuration, potentially resulting in an unexpected tracking
       vector.
@@ -544,12 +549,7 @@ Internet-Draft           Well-Known URI for ECH                June 2024
 
 10.1.  Normative References
 
-   [I-D.ietf-tls-esni]
-              Rescorla, E., Oku, K., Sullivan, N., and C. Wood, "TLS
-              Encrypted Client Hello", draft-ietf-tls-esni-18 (work in
-              progress), March 2024,
-              <https://datatracker.ietf.org/doc/html/draft-ietf-tls-
-              esni-18>.
+
 
 
 
@@ -561,6 +561,13 @@ Farrell, et al.         Expires December 14, 2024              [Page 10]
 
 Internet-Draft           Well-Known URI for ECH                June 2024
 
+
+   [I-D.ietf-tls-esni]
+              Rescorla, E., Oku, K., Sullivan, N., and C. Wood, "TLS
+              Encrypted Client Hello", draft-ietf-tls-esni-18 (work in
+              progress), March 2024,
+              <https://datatracker.ietf.org/doc/html/draft-ietf-tls-
+              esni-18>.
 
    [I-D.ietf-tls-svcb-ech]
               Schwartz, B., Bishop, M., and E. Nygren, "Bootstrapping
@@ -596,13 +603,6 @@ Internet-Draft           Well-Known URI for ECH                June 2024
    [ISOMORPHIC-DECODE]
               WHATWG, "WHATWG definition of Isomorphic Decode",
               <https://infra.spec.whatwg.org/#isomorphic-decode>.
-
-
-
-
-
-
-
 
 
 

--- a/draft-ietf-tls-wkech.txt
+++ b/draft-ietf-tls-wkech.txt
@@ -352,17 +352,23 @@ Internet-Draft           Well-Known URI for ECH                June 2024
    MUST be ignored.  The length of the list implies restrictions and
    meaning to the content of the entries:
 
-   o  An empty endpoints array corresponds to an HTTPS record with
-      inferred SvcPriority, the TargetName equal to ".", and no ECH
-      support.  This can can be useful as a simple way to make use of
-      the HTTPS RR type's HSTS behavior.
-   o  An endpoints array with one element can be either a ServiceMode
-      entry, containing at least one key from the JSON HTTP Origin Info
-      registry (see IANA Considerations (Section 9), below) or an
-      AliasMode entry that points to another DNS name that must be
-      resolved.
-   o  If the endpoints array has more than one element, every item MUST
-      be a ServiceMode entry.
+   o  An empty endpoints array means that all HTTPS records that the ZF
+      has published for the origin should be deleted.
+   o  An endpoints array with one element what can be one of three
+      things:
+
+      *  An empty object, which the ZF should take to be an HTTPS record
+         with inferred SvcPriority, a TargetName equal to ".", and no
+         ECH support.  This can can be useful as a simple way to make
+         use of the HTTPS RR type's HSTS behavior.
+      *  A ServiceMode entry, containing at least one key from the JSON
+         HTTP Origin Info registry (see IANA Considerations (Section 9),
+         below).
+      *  An AliasMode entry that points to another DNS name that must be
+         resolved.
+   o  If the endpoints array has more than one element, every item
+      SHOULD be a ServiceMode entry, due to restrictions on the use of
+      multiple AliasMode records (see , Section 2.4.2 [RFC9460]).
 
    The intent of these restrictions is to reduce the chance of
    misconfiguration by the ZF and to avoid introducing semantics not
@@ -380,12 +386,6 @@ Internet-Draft           Well-Known URI for ECH                June 2024
       name, corresponding to the HTTPS record's TargetName.  The default
       value is ".".  All labels in the name MUST contain only octets
       from the ABNF set ALPHA / DIGIT / "-" / "_".
-   o  priority: The value is a positive integer corresponding to the
-      SvcPriority.  If omitted, the ZF MAY infer numerically increasing
-      SvcPriority from the order of the endpoints array.
-   o  params: A JSON Dictionary representing the SVCB SvcParams.  Each
-      key in the dictionary is a string containing a registered
-
 
 
 
@@ -394,8 +394,13 @@ Farrell, et al.         Expires December 14, 2024               [Page 7]
 Internet-Draft           Well-Known URI for ECH                June 2024
 
 
+   o  priority: The value is a positive integer corresponding to the
+      SvcPriority.  If omitted, the ZF MAY infer numerically increasing
+      SvcPriority from the order of the endpoints array.
+   o  params: A JSON Dictionary representing the SVCB SvcParams.  Each
+      key in the dictionary is a string containing a registered
       SvcParamKey name (e.g., "ipv6hint") or a SvcParamKey in generic
-      form (e.g., "key65528").
+      form (e.g., "key65528").  The default value is "{}".
 
       *  For single-valued SvcParams (e.g., "ech"), the value is a JSON
          String.  A JSON String is a sequence of Unicode codepoints,
@@ -417,31 +422,26 @@ Internet-Draft           Well-Known URI for ECH                June 2024
       this directive by publishing an AliasMode record, publishing a
       CNAME record, copying HTTPS records from the target zone, or
       fetching https://cfs.example.com/.well-known/origin-svcb (if it
-      exists).  In this case, the regeninterval indicates that backend
-      does not plan to change the content at the URL for at least that
-      number of seconds.  If an alias entry is present then any ech and
-      port entries (if also present) MUST be ignored.
+      exists).
 
    These definitions, taken with the ZF behaviour (Section 6) specified
    below, provide the following important properties:
 
-   o  Origins can indicate that different ECHConfigs are used on
-      different ports.
-   o  Origins can indicate that multiple CDNs are in use, each with its
-      own ECHConfig.
+   o  Origins can express any useful configuration that is representable
+      by HTTPS records, including multiple endpoints representing
+      different ports, providers, etc.
    o  Origins that simply alias to a single target can indicate this
-      without copying the ECHConfig and other parameters, which can
-      interfere with key rotation and other maintenance.
-   o  "port" and "target" are generally sufficient to uniquely identify
-      a ServiceMode record, so zone factories can use the endpoint list
-      to add ECH to pre-existing ServiceMode records that may have other
-      SvcParams.
+      without copying the ECHConfig and other parameters, avoiding the
+      maintenance burden of staying synchronized with the target's key
+      rotations and configuration updates.
 
 6.  Zone Factory behaviour
 
    If the ZF is unable to convert the JSON into a DNS zone (e.g., due to
    an unrecognized SvcParamKey), or if the resulting zone fails
    validation checks, the ZF MUST NOT update the DNS.  Such failures
+   will not be directly visible to the client-facing server, so ZF
+   implementations will need to provide some form of reporting so that
 
 
 
@@ -450,8 +450,6 @@ Farrell, et al.         Expires December 14, 2024               [Page 8]
 Internet-Draft           Well-Known URI for ECH                June 2024
 
 
-   will not be directly visible to the client-facing server, so ZF
-   implementations will need to provide some form of reporting so that
    the situation can be resolved.  Note that this can lead to
    inconsistent behavior for a single origin served by multiple ZFs.
 
@@ -498,6 +496,8 @@ Internet-Draft           Well-Known URI for ECH                June 2024
 
    o  The bootstrap connection would not be able to use ECH, so it would
       reveal all the information that ECH seeks to protect.
+
+
 
 
 

--- a/draft-ietf-tls-wkech.xml
+++ b/draft-ietf-tls-wkech.xml
@@ -401,7 +401,7 @@ Client <-->|                    | |                    | facing
 	  params: A JSON Dictionary representing the SVCB SvcParams.  Each
 	  key in the dictionary is a string containing a registered
 	  SvcParamKey name (e.g., "ipv6hint") or a SvcParamKey in generic
-	  form (e.g., "key65528").
+	  form (e.g., "key65528").  The default value is "{}".
 	<list>
 	  <t>
 	      For single-valued SvcParams (e.g., "ech"), the value is a JSON

--- a/draft-ietf-tls-wkech.xml
+++ b/draft-ietf-tls-wkech.xml
@@ -310,15 +310,14 @@ Client <-->|                    | |                    | facing
 <figure anchor="sample-json" title="Sample JSON for ECH without aliases" >
 <artwork><![CDATA[
     {
+        "regeninterval": 3600,
         "endpoints": [{
-            "regeninterval": 3600,
             "priority": 1,
             "target": "cdn.example.",
             "params": {
                 "ech": "AD7+DQA65wAgAC..AA=="
             }
         }, {
-            "regeninterval": 3600,
             "priority": 1,
             "params": {
                 "port": 8413,
@@ -332,9 +331,9 @@ Client <-->|                    | |                    | facing
 <figure anchor="sample-json-alias" title="Sample JSON with aliasing" >
     <artwork><![CDATA[
      {
+        "regeninterval": 108000,
         "endpoints": [{
-            "alias": "cdn2.example.com",
-            "regeninterval": 108000
+            "alias": "cdn1.example.com",
         }]
       }
     ]]></artwork>
@@ -342,10 +341,22 @@ Client <-->|                    | |                    | facing
 
     <t>
         The JSON file at the well-known URI MUST contain an object
-	with an "endpoints" key that contains an array of objects.
+	with an two keys: "regeninterval", whose value is a number, and "endpoints"
+	whose value is an array of objects.
         All other keys MUST be ignored.
-        The length of the list implies restrictions and meaning to the content
-        of the entries:
+    </t>
+    <t>
+	The "regeninterval" must be a number greater than zero
+	and specifies the number of seconds between key generation
+	actions at the origin, i.e. a replacement ECHConfigList may be
+	generated this often.
+	This is used by the ZF to generate DNS TTL values and to determine
+        when to next poll the origin for updates.
+    </t>
+    <t>
+        The "endpoints" key is an array of objects. The number of items in
+        the array implies restrictions and meaning to the content
+        of the items:
     <list style="symbols">
       <t>
 	  An empty endpoints array means that all HTTPS records that the
@@ -379,20 +390,11 @@ Client <-->|                    | |                    | facing
       </t>
     </list>
     </t>
+
     <t>
 	This format is designed to allow full use of the capabilities of
         HTTPS records <xref target="RFC9460"/> in natural JSON
         while minimizing the risk of invalid configurations.
-    </t>
-
-    <t>The following keys are defined for both types of entries:
-    <list style="symbols">
-      <t>
-	  regeninterval: the number of seconds between key generation
-	  actions at the origin, i.e. a replacement ECHConfigList may be
-	  generated this often.
-      </t>
-    </list>
     </t>
 
     <t>The following keys are defined for ServiceMode entries:

--- a/draft-ietf-tls-wkech.xml
+++ b/draft-ietf-tls-wkech.xml
@@ -442,23 +442,13 @@ Client <-->|                    | |                    | facing
       specified below, provide the following important properties:
       <list style="symbols">
 	<t>
-	    Origins can indicate that different ECHConfigs are used on
-	    different ports.
-	</t>
-	<t>
-	    Origins can indicate that multiple CDNs are in use, each with
-	    its own ECHConfig.
+	    Origins can express any useful configuration that is representable by HTTPS records, including multiple endpoints representing different ports, providers, etc.
 	</t>
 	<t>
 	    Origins that simply alias to a single target can indicate this
-	    without copying the ECHConfig and other parameters, which
-	    can interfere with key rotation and other maintenance.
-	</t>
-	<t>
-	    "port" and "target" are generally sufficient to uniquely identify
-	    a ServiceMode record, so zone factories can use the endpoint list
-	    to add ECH to pre-existing ServiceMode records that may have other
-	    SvcParams.
+	    without copying the ECHConfig and other parameters, avoiding
+	    the maintenance burden of staying synchronized with the target's
+	    key rotations and configuration updates.
 	</t>
       </list>
     </t>

--- a/draft-ietf-tls-wkech.xml
+++ b/draft-ietf-tls-wkech.xml
@@ -380,9 +380,9 @@ Client <-->|                    | |                    | facing
     </list>
     </t>
     <t>
-	The intent of these restrictions is to reduce the chance of misconfiguration
-	by the ZF and to avoid introducing semantics not defined by
-        <xref target="RFC9460"/>.
+	This format is designed to allow full use of the capabilities of
+        HTTPS records <xref target="RFC9460"/> in natural JSON
+        while minimizing the risk of invalid configurations.
     </t>
 
     <t>The following keys are defined for both types of entries:

--- a/draft-ietf-tls-wkech.xml
+++ b/draft-ietf-tls-wkech.xml
@@ -348,22 +348,34 @@ Client <-->|                    | |                    | facing
         of the entries:
     <list style="symbols">
       <t>
-        An empty endpoints array corresponds to an HTTPS record with inferred
-        SvcPriority, the TargetName equal to ".", and no ECH support.  This can
-        can be useful as a simple way to make use of the HTTPS RR
-        type's HSTS behavior.
-      </t>
+	  An empty endpoints array means that all HTTPS records that the
+	  ZF has published for the origin should be deleted.
+	</t>
       <t>
-	An endpoints array with one element can be either a ServiceMode
-	entry, containing at least one key from the JSON HTTP Origin Info
-	registry (see <xref target="iana">IANA Considerations</xref>, below)
-	or an AliasMode entry that points to another DNS name that must
-        be resolved.
+	  An endpoints array with one element what can be one of
+	  three things:
+	<list style="symbols">
+	  <t>
+	    An empty object, which the ZF should take to be an HTTPS record
+	    with inferred SvcPriority, a TargetName equal to ".", and no ECH
+	    support. This can can be useful as a simple way to make use of
+	    the HTTPS RR type's HSTS behavior.
+	  </t>
+	  <t>
+	      A ServiceMode entry, containing at least one key from the JSON
+	      HTTP Origin Info registry (see <xref target="iana">IANA
+	      Considerations</xref>, below).
+	  </t>
+	  <t>
+	    An AliasMode entry that points to another DNS name that must
+	    be resolved.
+	  </t>
+	  </list>
       </t>
       <t>
 	If the endpoints array has more than one element, every item SHOULD
         be a ServiceMode entry, due to restrictions on the use of multiple AliasMode
-        records (<relref target="RFC9460" section="2.4.2" displayFormat="comma" />).
+	  records (see <xref target="RFC9460">, Section 2.4.2</xref>).
       </t>
     </list>
     </t>

--- a/draft-ietf-tls-wkech.xml
+++ b/draft-ietf-tls-wkech.xml
@@ -400,8 +400,7 @@ Client <-->|                    | |                    | facing
       <t>
 	  target: The value is a string containing a fully qualified
 	  domain name, corresponding to the HTTPS record's TargetName.
-	  The default value is ".".  All labels in the name MUST contain
-	  only octets from the ABNF set ALPHA / DIGIT / "-" / "_".
+	  The default value is ".".
       </t>
       <t>
 	  priority: The value is a positive integer corresponding to the

--- a/draft-ietf-tls-wkech.xml
+++ b/draft-ietf-tls-wkech.xml
@@ -361,8 +361,9 @@ Client <-->|                    | |                    | facing
         be resolved.
       </t>
       <t>
-	If the endpoints array has more than one element, every item MUST
-        be a ServiceMode entry.
+	If the endpoints array has more than one element, every item SHOULD
+        be a ServiceMode entry, due to restrictions on the use of multiple AliasMode
+        records (<relref target="RFC9460" section="2.4.2" displayFormat="comma" />).
       </t>
     </list>
     </t>

--- a/draft-ietf-tls-wkech.xml
+++ b/draft-ietf-tls-wkech.xml
@@ -405,6 +405,9 @@ Client <-->|                    | |                    | facing
 	  The default value is ".".
       </t>
       <t>
+           [[ TODO: Restrict the allowed characters or specify the encoding rules for TargetName. ]]
+      </t>
+      <t>
 	  priority: The value is a positive integer corresponding to the
 	  SvcPriority.  If omitted, the ZF MAY infer
 	  numerically increasing SvcPriority from the order of the

--- a/draft-ietf-tls-wkech.xml
+++ b/draft-ietf-tls-wkech.xml
@@ -333,9 +333,6 @@ Client <-->|                    | |                    | facing
     <artwork><![CDATA[
      {
         "endpoints": [{
-            "alias": "cdn1.example.net",
-            "regeninterval": 108000
-        }, {
             "alias": "cdn2.example.com",
             "regeninterval": 108000
         }]
@@ -347,20 +344,32 @@ Client <-->|                    | |                    | facing
         The JSON file at the well-known URI MUST contain an object
 	with an "endpoints" key that contains an array of objects.
         All other keys MUST be ignored.
-    </t>
-    <t>
-        The endpoints array MUST be a homogeneous collection of objects,
-	where every entry is either a SerivceMode entry containing
-	at least one key from the JSON HTTP Origin Info registry
-        (see IANA Considerations section), or every entry is an
-        AliasMode entry that points to another DNS name that must
-        be resolved.
-    </t>
-    <t>
-        An empty endpoint object corresponds to an HTTPS record with inferred
-        SvcPriority, TargetName=".", and no ECH support.  An empty record of
-        this kind can be useful as a simple way to make use of the HTTPS RR
+        The length of the list implies restrictions and meaning to the content
+        of the entries:
+    <list style="symbols">
+      <t>
+        An empty endpoints array corresponds to an HTTPS record with inferred
+        SvcPriority, the TargetName equal to ".", and no ECH support.  This can
+        can be useful as a simple way to make use of the HTTPS RR
         type's HSTS behavior.
+      </t>
+      <t>
+	An endpoints array with one element can be either a ServiceMode
+	entry, containing at least one key from the JSON HTTP Origin Info
+	registry (see <xref target="iana">IANA Considerations</xref>, below)
+	or an AliasMode entry that points to another DNS name that must
+        be resolved.
+      </t>
+      <t>
+	If the endpoints array has more than one element, every item MUST
+        be a ServiceMode entry.
+      </t>
+    </list>
+    </t>
+    <t>
+	The intent of these restrictions is to reduce the chance of misconfiguration
+	by the ZF and to avoid introducing semantics not defined by
+        <xref target="RFC9460"/>.
     </t>
 
     <t>The following keys are defined for both types of entries:
@@ -412,9 +421,7 @@ Client <-->|                    | |                    | facing
     </list>
   </t>
 
-    <t>The following key is defined for AliasMode entries.  If this key is
-      present than any ech or port keys within the params key MUST be
-      ignored.
+    <t>The following key is defined for AliasMode entries.
 
     <list style="symbols">
       <t>
@@ -562,7 +569,7 @@ Client <-->|                    | |                    | facing
             the Open Technology Fund.</t>
     </section>
 
-    <section title="IANA Considerations">
+    <section anchor="iana" title="IANA Considerations">
 	<t>[[ NOTE:
 	   IANA registration of a .well-known entry.
 	  ]]</t>
@@ -585,6 +592,7 @@ Client <-->|                    | |                    | facing
       <?rfc include='reference.RFC.8174'?>
       <?rfc include='reference.RFC.8446'?>
       <?rfc include='reference.RFC.8615'?>
+      <?rfc include='reference.RFC.9460'?>
       &I-D.ietf-tls-esni;
       &I-D.ietf-tls-svcb-ech;
 

--- a/draft-ietf-tls-wkech.xml
+++ b/draft-ietf-tls-wkech.xml
@@ -433,10 +433,7 @@ Client <-->|                    | |                    | facing
 	  this directive by publishing an AliasMode record, publishing a
 	  CNAME record, copying HTTPS records from the target zone, or
 	  fetching https://cfs.example.com/.well-known/origin-svcb (if it
-	  exists).  In this case, the regeninterval indicates that backend
-	  does not plan to change the content at the URL for at least that
-	  number of seconds.  If an alias entry is present then any ech and
-	  port entries (if also present) MUST be ignored.
+	  exists).
       </t>
     </list>
   </t>


### PR DESCRIPTION
Required the endpoitn array to be all of the same type: alias or service entries.  Do we want that???  Wording in the text is still contradictory, so we have to make up our minds :)