### PR TITLE
better split mode text

### DIFF
--- a/draft-ietf-tls-wkech.txt
+++ b/draft-ietf-tls-wkech.txt
@@ -76,18 +76,18 @@ Table of Contents
      3.2.  Split-mode deployment.  . . . . . . . . . . . . . . . . .   5
    4.  The origin-svcb well-known URI  . . . . . . . . . . . . . . .   7
    5.  The JSON structure for origin service binding info  . . . . .   7
-   6.  Zone Factory behaviour  . . . . . . . . . . . . . . . . . . .  10
-   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  11
-   8.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  12
-   9.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  12
+   6.  Zone Factory behaviour  . . . . . . . . . . . . . . . . . . .  11
+   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  12
+   8.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  13
+   9.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  13
      9.1.  Well-known endpoint registration  . . . . . . . . . . . .  13
-     9.2.  JSON Service Binding Info . . . . . . . . . . . . . . . .  13
-   10. References  . . . . . . . . . . . . . . . . . . . . . . . . .  14
-     10.1.  Normative References . . . . . . . . . . . . . . . . . .  14
-     10.2.  Informative References . . . . . . . . . . . . . . . . .  15
-   Appendix A.  Change Log . . . . . . . . . . . . . . . . . . . . .  15
-   Appendix B.  Examples . . . . . . . . . . . . . . . . . . . . . .  16
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  16
+     9.2.  JSON Service Binding Info . . . . . . . . . . . . . . . .  14
+   10. References  . . . . . . . . . . . . . . . . . . . . . . . . .  15
+     10.1.  Normative References . . . . . . . . . . . . . . . . . .  15
+     10.2.  Informative References . . . . . . . . . . . . . . . . .  16
+   Appendix A.  Change Log . . . . . . . . . . . . . . . . . . . . .  16
+   Appendix B.  Examples . . . . . . . . . . . . . . . . . . . . . .  17
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  17
 
 1.  Introduction
 
@@ -351,7 +351,8 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
        the generated HTTPS record(s), including the relevant ECH values,
        and confirms that all is working before updating the zone.
 
-   8.  Note that the ZF is not aware that ECH split-mode is in use.
+   Note that the in this example ZF does not necessarily know that ECH
+   split-mode is in use.
 
 4.  The origin-svcb well-known URI
 
@@ -365,7 +366,33 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
    If no new ECHConfig value verifies (as per Section 6), then the zone
    factory MUST NOT modify the zone.
 
+   With this scheme, web origins can only "speak for themselves" so that
+   if the backend is e.g. at port 8443 rather then the default 443, then
+   the ZF MUST access https://backend.example.com:8443/.well-known/
+   origin-scvb when considering modifications to the HTTPS/SVCB records
+   for _8443._https.example.com.  As a consequence, a ZF will need to be
+   configured to periodically refresh the JSON resource for each origin
+   separately, that is, a ZF cannot "discover" from port 443 that some
+   other service, for which the ZF is expected to update the DNS, is
+   also present on another port on the same host.
+
 5.  The JSON structure for origin service binding info
+
+
+
+
+
+
+
+
+
+
+
+
+Farrell, et al.          Expires 4 October 2025                 [Page 7]
+
+Internet-Draft           Well-Known URI for SVCB              April 2025
+
 
        {
            "regeninterval": 3600,
@@ -386,14 +413,6 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
 
                Figure 3: Sample JSON for ECH without aliases
 
-
-
-
-Farrell, et al.          Expires 4 October 2025                 [Page 7]
-
-Internet-Draft           Well-Known URI for SVCB              April 2025
-
-
         {
            "regeninterval": 108000,
            "endpoints": [{
@@ -412,6 +431,24 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
    a replacement ECHConfigList may be generated this often.  This is
    used by the ZF to generate DNS TTL values and to determine when to
    next poll the origin for updates.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Farrell, et al.          Expires 4 October 2025                 [Page 8]
+
+Internet-Draft           Well-Known URI for SVCB              April 2025
+
 
    More precise expiration times are common (e.g., the "notAfter" field
    in certificate lifetime validity, discussed in Section 4.1.2.5 of
@@ -441,15 +478,6 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
           HTTP Origin Info registry (see IANA Considerations
           (Section 9), below).
 
-
-
-
-
-Farrell, et al.          Expires 4 October 2025                 [Page 8]
-
-Internet-Draft           Well-Known URI for SVCB              April 2025
-
-
       3.  An AliasMode entry that points to another DNS name that must
           be resolved.
 
@@ -464,6 +492,20 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
    The following keys are defined for ServiceMode entries:
 
    target:  The value is a string containing a fully qualified domain
+
+
+
+
+
+
+
+
+
+Farrell, et al.          Expires 4 October 2025                 [Page 9]
+
+Internet-Draft           Well-Known URI for SVCB              April 2025
+
+
       name corresponding to the HTTPS record's TargetName with the final
       "." removed.  The default value is the empty string (""),
       corresponding to a TargetName of ".".  To avoid complex conversion
@@ -496,16 +538,6 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
    The following key is defined for AliasMode entries.
 
    alias:  The value MUST be a DNS name that could be used as the
-
-
-
-
-
-Farrell, et al.          Expires 4 October 2025                 [Page 9]
-
-Internet-Draft           Well-Known URI for SVCB              April 2025
-
-
       TargetName of an HTTPS resource record.  This indicates that the
       backend is hosted on the same endpoints as this target, and is
       equivalent to an HTTPS AliasMode record.  The ZF might implement
@@ -521,10 +553,27 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
       by HTTPS records, including multiple endpoints representing
       different ports, providers, etc.
 
+
+
+
+
+Farrell, et al.          Expires 4 October 2025                [Page 10]
+
+Internet-Draft           Well-Known URI for SVCB              April 2025
+
+
    *  Origins that simply alias to a single target can indicate this
       without copying the ECHConfig and other parameters, avoiding the
       maintenance burden of staying synchronized with the target's key
       rotations and configuration updates.
+
+   Note that there are multiple, and possibly confusing, port numbers
+   involved here.  The port that is part of the web origin in the .well-
+   known URL is part of the QNAME that will be used by clients in
+   accessing the origin's HTTPS/SVCB resource records.  The "port" field
+   in the RR value, and in the JSON structure, is the value to be used
+   in specifying an "alternative endpoint" as defined in section 1.3
+   [RFC9460].
 
 6.  Zone Factory behaviour
 
@@ -554,14 +603,6 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
    values with one public key in each, and then test each of those
    separately.
 
-
-
-
-Farrell, et al.          Expires 4 October 2025                [Page 10]
-
-Internet-Draft           Well-Known URI for SVCB              April 2025
-
-
    If ipv4hints or ipv6hints are present, and if those are not the same
    values as are published in A/AAAA RRs for the backend, then the ZF
    SHOULD check that webPKI based authentication of the backend works at
@@ -569,6 +610,13 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
 
    A ZF SHOULD publish all the endpoints that are presented in the JSON
    file that pass the checks above.
+
+
+
+Farrell, et al.          Expires 4 October 2025                [Page 11]
+
+Internet-Draft           Well-Known URI for SVCB              April 2025
+
 
    A ZF SHOULD set a DNS TTL less than regeninterval, i.e. short enough
    so that any cached DNS resource records are likely to have expired
@@ -610,14 +658,6 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
    with the HTTP-01 challenge type.  A temporary breach of a backend
    server that allows the attacker to contol the JSON content described
    here could be used to bootsrap more long-lasting control over the
-
-
-
-Farrell, et al.          Expires 4 October 2025                [Page 11]
-
-Internet-Draft           Well-Known URI for SVCB              April 2025
-
-
    backend's DNS name if the attacker were to request new certificates
    during the time when the attacker's chosen values were published in
    the DNS, and if the ACME server doing the validation solely depended
@@ -625,6 +665,14 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
    over the AAAA for the backend.  It would seem prudent for ACME
    servers to be cautious if using ipv4hints and ipv6hints, e.g.
    flagging divergence between those values and A/AAAA RRs.
+
+
+
+
+Farrell, et al.          Expires 4 October 2025                [Page 12]
+
+Internet-Draft           Well-Known URI for SVCB              April 2025
+
 
    Although the .well-known URL defined here may well be publicly
    accessible, general HTTP clients SHOULD NOT attempt to use this
@@ -637,11 +685,6 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
    *  The origin could serve the user with a uniquely identifying
       configuration, potentially resulting in an unexpected tracking
       vector.
-
-   The .well-known URI chosen here means that services running on
-   different ports of the same backend are trusting the service running
-   on the default port (443) for that backend to provide correct
-   endpoint information.
 
    As described, in mutlti-CDN and simlar scenarios, a ZF might only
    test ECH success against one of the CDNs unless the ZF can make use
@@ -664,20 +707,28 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
    registry for defining items in the JSON object found at that
    endpoint.
 
-
-
-
-
-
-Farrell, et al.          Expires 4 October 2025                [Page 12]
-
-Internet-Draft           Well-Known URI for SVCB              April 2025
-
-
 9.1.  Well-known endpoint registration
 
    IANA is requested to add the following entry to the Well-Known URIs
    table:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Farrell, et al.          Expires 4 October 2025                [Page 13]
+
+Internet-Draft           Well-Known URI for SVCB              April 2025
+
 
             +---------------------+---------------------------+
             | Column              | Value                     |
@@ -725,7 +776,12 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
 
 
 
-Farrell, et al.          Expires 4 October 2025                [Page 13]
+
+
+
+
+
+Farrell, et al.          Expires 4 October 2025                [Page 14]
 
 Internet-Draft           Well-Known URI for SVCB              April 2025
 
@@ -781,7 +837,7 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
 
 
 
-Farrell, et al.          Expires 4 October 2025                [Page 14]
+Farrell, et al.          Expires 4 October 2025                [Page 15]
 
 Internet-Draft           Well-Known URI for SVCB              April 2025
 
@@ -837,7 +893,7 @@ Appendix A.  Change Log
 
 
 
-Farrell, et al.          Expires 4 October 2025                [Page 15]
+Farrell, et al.          Expires 4 October 2025                [Page 16]
 
 Internet-Draft           Well-Known URI for SVCB              April 2025
 
@@ -849,7 +905,8 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
    Version 06 changed the name and some of the text because it is no
    longer ECH-specific.
 
-   Version 07 has editorial changes and clarifications.
+   Version 07 clarifies that origins only speak for themselves and has
+   editorial changes and clarifications.
 
 Appendix B.  Examples
 
@@ -892,5 +949,4 @@ Authors' Addresses
 
 
 
-
-Farrell, et al.          Expires 4 October 2025                [Page 16]
+Farrell, et al.          Expires 4 October 2025                [Page 17]

--- a/draft-ietf-tls-wkech.txt
+++ b/draft-ietf-tls-wkech.txt
@@ -319,7 +319,7 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
    but with the following differences: but with the following
    differences:
 
-   1.  The client-facing server, (CDS), is a load-balancer and only does
+   1.  The client-facing server, (CFS), is a load-balancer and only does
        ECH decryption.  The load-balancer is called cfs.lb.example.
 
    2.  Traffic between the CFS and backend is protected using some kind

--- a/draft-ietf-tls-wkech.txt
+++ b/draft-ietf-tls-wkech.txt
@@ -293,8 +293,8 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
                        +--------------------+
                        |                    |
         TLS            |   2001:DB8::1111   |
-       Client <-->     |backend.example.com |
-                       |     cfs.example    |
+        Client <---->  |backend.example.com |
+                       |   cfs.lb.example   |
                        +--------------------+
                            ^            ^
         (3) ZF reads       |            |  (4) ZF checks
@@ -319,17 +319,17 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
    but with the following differences: but with the following
    differences:
 
-   1.  ECH split-mode is supported by the CDN.
+   1.  The client-facing server, (CDS), is a load-balancer and only does
+       ECH decryption.  The load-balancer is called cfs.lb.example.
 
-   2.  The client-facing server, e.g. in a CDN, for the backend server
-       only does ECH decryption.
-
-   3.  Traffic between the CFS and backend is protected using some kind
+   2.  Traffic between the CFS and backend is protected using some kind
        of VPN.
 
-   4.  The A/AAAA values for backend.example.com and cfs.cdn.example are
+   3.  The A/AAAA values for backend.example.com and cfs.lb.example are
        the same.
 
+   4.  backend.example.com content is hosted on some machine(s)
+       accessible via the CFS and via the VPN.
 
 
 
@@ -338,23 +338,20 @@ Farrell, et al.          Expires 4 October 2025                 [Page 6]
 Internet-Draft           Well-Known URI for SVCB              April 2025
 
 
-   5.  backend.example.com content is hosted on some machine(s)
-       accessible via the client-facing servers and via the VPN.
-
-   6.  backend.example.com has to acquire the ECH config information
+   5.  backend.example.com wants to acquire the ECH config information
        from the CFS by querying the CFS' .well-known URL, in this case
-       https://cfs.cds.example/.well-known/origin-svcb
+       https://cfs.lb.example/.well-known/origin-svcb
 
-   7.  backend.example.com then publishes its chosen JSON (presumably
+   6.  backend.example.com then publishes its chosen JSON (presumably
        including the relevant ECH config information) at
        https://backend.example.com/.well-known/origin-svcb That resource
        is hosted on the "real" backend.example.com machine.
 
-   8.  The ZF attempts to connect to https://backend.example.com using
+   7.  The ZF attempts to connect to https://backend.example.com using
        the generated HTTPS record(s), including the relevant ECH values,
        and confirms that all is working before updating the zone.
 
-   9.  Note that the ZF is not aware that ECH split-mode is in use.
+   8.  Note that the ZF is not aware that ECH split-mode is in use.
 
 4.  The origin-svcb well-known URI
 
@@ -387,14 +384,15 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
            }]
        }
 
+               Figure 3: Sample JSON for ECH without aliases
+
+
 
 
 Farrell, et al.          Expires 4 October 2025                 [Page 7]
 
 Internet-Draft           Well-Known URI for SVCB              April 2025
 
-
-               Figure 3: Sample JSON for ECH without aliases
 
         {
            "regeninterval": 108000,
@@ -442,6 +440,8 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
       2.  A ServiceMode entry, containing at least one key from the JSON
           HTTP Origin Info registry (see IANA Considerations
           (Section 9), below).
+
+
 
 
 

--- a/draft-ietf-tls-wkech.txt
+++ b/draft-ietf-tls-wkech.txt
@@ -73,19 +73,20 @@ Table of Contents
    2.  Terminology . . . . . . . . . . . . . . . . . . . . . . . . .   3
    3.  Example uses of the well-known URI for ECH  . . . . . . . . .   4
      3.1.  Shared-mode deplpoyment.  . . . . . . . . . . . . . . . .   4
-     3.2.  Split-mode, multi-CDN deplpoyment.  . . . . . . . . . . .   5
+     3.2.  Split-mode deployment.  . . . . . . . . . . . . . . . . .   5
    4.  The origin-svcb well-known URI  . . . . . . . . . . . . . . .   7
    5.  The JSON structure for origin service binding info  . . . . .   7
    6.  Zone Factory behaviour  . . . . . . . . . . . . . . . . . . .  10
    7.  Security Considerations . . . . . . . . . . . . . . . . . . .  11
    8.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  12
    9.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  12
-     9.1.  Well-known endpoint registration  . . . . . . . . . . . .  12
+     9.1.  Well-known endpoint registration  . . . . . . . . . . . .  13
      9.2.  JSON Service Binding Info . . . . . . . . . . . . . . . .  13
    10. References  . . . . . . . . . . . . . . . . . . . . . . . . .  14
      10.1.  Normative References . . . . . . . . . . . . . . . . . .  14
      10.2.  Informative References . . . . . . . . . . . . . . . . .  15
    Appendix A.  Change Log . . . . . . . . . . . . . . . . . . . . .  15
+   Appendix B.  Examples . . . . . . . . . . . . . . . . . . . . . .  16
    Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  16
 
 1.  Introduction
@@ -97,7 +98,6 @@ Table of Contents
    connections to services by using a new DNS record set (RRset).  The
    [I-D.ietf-tls-svcb-ech] document defines an entry in that RRset for
    Encrypted Client Hello (ECH).
-
 
 
 
@@ -257,15 +257,15 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
    its cached copy of the JSON resource.  If the resource has changed,
    it repeats this process.
 
-3.2.  Split-mode, multi-CDN deplpoyment.
+3.2.  Split-mode deployment.
 
    The following diagram, and this entire section, is a place-holder
    just to have something on which to base discussion, and will change.
 
-
-
-
-
+   In this section, we describe one possible way in which ECH split-mode
+   could be deployed and make use of this .well-known scheme.  There are
+   of course various other deployment options that might be more
+   effective.
 
 
 
@@ -287,17 +287,17 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
                        | backend.example.com|
                        |                    |
                        +--------------------+
-                           ^^           ^^
-                           ||    VPN    ||
-                           VV           VV
-              +--------------------+ +--------------------+
-              |                    | |                    |
-    TLS       |   2001:DB8::1111   | |   2001:DB8::FFFF   | Client-
-   Client <-->|backend.example.com | | backend.example.com| facing
-              |  cfs.cdn1.example  | |  cfs.cdn2.example  | servers
-              +--------------------+ +--------------------+
+         (1) backend       ^^           ^^   (2) backend publishes
+             reads CFS'    ||    VPN    ||       backend's
+             .well-known   VV           VV       .well-known
+                       +--------------------+
+                       |                    |
+        TLS            |   2001:DB8::1111   |
+       Client <-->     |backend.example.com |
+                       |     cfs.example    |
+                       +--------------------+
                            ^            ^
-        (1) ZF reads       |            |  (2) ZF checks
+        (3) ZF reads       |            |  (4) ZF checks
             .well-known    V            V      ECHConfig
                        +--------------------+
                        |                    |
@@ -305,7 +305,7 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
                        |                    |
                        +--------------------+
                                  |
-                                 | (3) ZF publishes new HTTPS RR
+                                 | (5) ZF publishes new HTTPS RR
                                  V
                        +--------------------+
                        |                    |
@@ -313,22 +313,22 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
                        |                    |
                        +--------------------+
 
-          Figure 2: Shared-Mode Topology with Zone Factory and DNS
+          Figure 2: Split-Mode Topology with Zone Factory and DNS
 
    In this topology, the overall process is as in the previous section,
-   but with the following differences:
+   but with the following differences: but with the following
+   differences:
 
-   1.  There are two client-facing servers (in different CDNs) for the
-       one "REAL" backend server that hosts the actual web resources.
+   1.  ECH split-mode is supported by the CDN.
 
-   2.  ECH split-mode is assumed to be supported by both CDNs.
+   2.  The client-facing server, e.g. in a CDN, for the backend server
+       only does ECH decryption.
 
-   3.  The "REAL" backend.example.com content is hosted on some
-       machine(s) accessible from the client-facing servers via a VPN.
+   3.  Traffic between the CFS and backend is protected using some kind
+       of VPN.
 
-   4.  The ZF notes that backend.example.com has multiple AAAA RR values
-       published, so queries for the .well-known at each of those.  In
-       this case the values received differ.
+   4.  The A/AAAA values for backend.example.com and cfs.cdn.example are
+       the same.
 
 
 
@@ -338,10 +338,23 @@ Farrell, et al.          Expires 4 October 2025                 [Page 6]
 Internet-Draft           Well-Known URI for SVCB              April 2025
 
 
-   5.  The ZF next attempts to connect to each CFS using the relevant
-       ECH values and confirms that they are all working.
+   5.  backend.example.com content is hosted on some machine(s)
+       accessible via the client-facing servers and via the VPN.
 
-   6.  Note tha the ZF is not aware that ECH split-mode is in use.
+   6.  backend.example.com has to acquire the ECH config information
+       from the CFS by querying the CFS' .well-known URL, in this case
+       https://cfs.cds.example/.well-known/origin-svcb
+
+   7.  backend.example.com then publishes its chosen JSON (presumably
+       including the relevant ECH config information) at
+       https://backend.example.com/.well-known/origin-svcb That resource
+       is hosted on the "real" backend.example.com machine.
+
+   8.  The ZF attempts to connect to https://backend.example.com using
+       the generated HTTPS record(s), including the relevant ECH values,
+       and confirms that all is working before updating the zone.
+
+   9.  Note that the ZF is not aware that ECH split-mode is in use.
 
 4.  The origin-svcb well-known URI
 
@@ -374,6 +387,13 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
            }]
        }
 
+
+
+Farrell, et al.          Expires 4 October 2025                 [Page 7]
+
+Internet-Draft           Well-Known URI for SVCB              April 2025
+
+
                Figure 3: Sample JSON for ECH without aliases
 
         {
@@ -384,15 +404,6 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
          }
 
                     Figure 4: Sample JSON with aliasing
-
-
-
-
-
-Farrell, et al.          Expires 4 October 2025                 [Page 7]
-
-Internet-Draft           Well-Known URI for SVCB              April 2025
-
 
    The JSON file at the well-known URI MUST contain an object with two
    keys: "regeninterval", whose value is a number, and "endpoints" whose
@@ -432,6 +443,13 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
           HTTP Origin Info registry (see IANA Considerations
           (Section 9), below).
 
+
+
+Farrell, et al.          Expires 4 October 2025                 [Page 8]
+
+Internet-Draft           Well-Known URI for SVCB              April 2025
+
+
       3.  An AliasMode entry that points to another DNS name that must
           be resolved.
 
@@ -442,13 +460,6 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
    This format is designed to allow full use of the capabilities of
    HTTPS records [RFC9460] in natural JSON while minimizing the risk of
    invalid configurations.
-
-
-
-Farrell, et al.          Expires 4 October 2025                 [Page 8]
-
-Internet-Draft           Well-Known URI for SVCB              April 2025
-
 
    The following keys are defined for ServiceMode entries:
 
@@ -485,6 +496,16 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
    The following key is defined for AliasMode entries.
 
    alias:  The value MUST be a DNS name that could be used as the
+
+
+
+
+
+Farrell, et al.          Expires 4 October 2025                 [Page 9]
+
+Internet-Draft           Well-Known URI for SVCB              April 2025
+
+
       TargetName of an HTTPS resource record.  This indicates that the
       backend is hosted on the same endpoints as this target, and is
       equivalent to an HTTPS AliasMode record.  The ZF might implement
@@ -495,16 +516,6 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
 
    These definitions, taken with the ZF behaviour (Section 6) specified
    below, provide the following important properties:
-
-
-
-
-
-
-Farrell, et al.          Expires 4 October 2025                 [Page 9]
-
-Internet-Draft           Well-Known URI for SVCB              April 2025
-
 
    *  Origins can express any useful configuration that is representable
       by HTTPS records, including multiple endpoints representing
@@ -543,6 +554,14 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
    values with one public key in each, and then test each of those
    separately.
 
+
+
+
+Farrell, et al.          Expires 4 October 2025                [Page 10]
+
+Internet-Draft           Well-Known URI for SVCB              April 2025
+
+
    If ipv4hints or ipv6hints are present, and if those are not the same
    values as are published in A/AAAA RRs for the backend, then the ZF
    SHOULD check that webPKI based authentication of the backend works at
@@ -554,14 +573,6 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
    A ZF SHOULD set a DNS TTL less than regeninterval, i.e. short enough
    so that any cached DNS resource records are likely to have expired
    before the JSON object's content is likely to have changed.  The ZF
-
-
-
-Farrell, et al.          Expires 4 October 2025                [Page 10]
-
-Internet-Draft           Well-Known URI for SVCB              April 2025
-
-
    MUST attempt to refresh the JSON object and regenerate the zone
    before this time.  This aims to ensure that ECHConfig values are not
    used longer than intended by backend.
@@ -599,17 +610,6 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
    with the HTTP-01 challenge type.  A temporary breach of a backend
    server that allows the attacker to contol the JSON content described
    here could be used to bootsrap more long-lasting control over the
-   backend's DNS name if the attacker were to request new certificates
-   during the time when the attacker's chosen values were published in
-   the DNS, and if the ACME server doing the validation solely depended
-   on content from the backend's HTTPS RR, e.g. preferring ipv6hints
-   over the AAAA for the backend.  It would seem prudent for ACME
-   servers to be cautious if using ipv4hints and ipv6hints, e.g.
-   flagging divergence between those values and A/AAAA RRs.
-
-
-
-
 
 
 
@@ -617,6 +617,14 @@ Farrell, et al.          Expires 4 October 2025                [Page 11]
 
 Internet-Draft           Well-Known URI for SVCB              April 2025
 
+
+   backend's DNS name if the attacker were to request new certificates
+   during the time when the attacker's chosen values were published in
+   the DNS, and if the ACME server doing the validation solely depended
+   on content from the backend's HTTPS RR, e.g. preferring ipv6hints
+   over the AAAA for the backend.  It would seem prudent for ACME
+   servers to be cautious if using ipv4hints and ipv6hints, e.g.
+   flagging divergence between those values and A/AAAA RRs.
 
    Although the .well-known URL defined here may well be publicly
    accessible, general HTTP clients SHOULD NOT attempt to use this
@@ -656,14 +664,6 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
    registry for defining items in the JSON object found at that
    endpoint.
 
-9.1.  Well-known endpoint registration
-
-   IANA is requested to add the following entry to the Well-Known URIs
-   table:
-
-
-
-
 
 
 
@@ -673,6 +673,11 @@ Farrell, et al.          Expires 4 October 2025                [Page 12]
 
 Internet-Draft           Well-Known URI for SVCB              April 2025
 
+
+9.1.  Well-known endpoint registration
+
+   IANA is requested to add the following entry to the Well-Known URIs
+   table:
 
             +---------------------+---------------------------+
             | Column              | Value                     |
@@ -713,11 +718,6 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
    The table should be populated with the following two entries, where
    Items in curly braces should be replaced with their actual values,
    and the "Notes" column is empty.
-
-
-
-
-
 
 
 
@@ -851,6 +851,10 @@ Internet-Draft           Well-Known URI for SVCB              April 2025
 
    Version 07 has editorial changes and clarifications.
 
+Appendix B.  Examples
+
+   TBD - add some examples with names, JSON etc. and brief explanations.
+
 Authors' Addresses
 
    Stephen Farrell
@@ -870,10 +874,6 @@ Authors' Addresses
    Benjamin Schwartz
    Meta Platforms, Inc.
    Email: ietf@bemasc.net
-
-
-
-
 
 
 

--- a/draft-ietf-tls-wkech.xml
+++ b/draft-ietf-tls-wkech.xml
@@ -234,6 +234,14 @@ Client <----------->|                    | facing
 	  <t>
           The following diagram, and this entire section, is a place-holder just
           to have something on which to base discussion, and will change.</t>
+
+        <t>
+            In this section, we describe one possible way in which ECH
+            split-mode could be deployed and make use of this .well-known
+            scheme. There are of course various other deployment options that
+            might be more effective.
+        </t>
+
 <figure title="Split-Mode Topology with Zone Factory and DNS" anchor="split-mode"><artwork><![CDATA[
 
                     +--------------------+
@@ -809,6 +817,9 @@ Client <----------->|                    | facing
           and has editorial changes and clarifications.
       </t>
 
+    </section>
+    <section title="Examples">
+        <t>TBD - add some examples with names, JSON etc. and brief explanations.</t>
     </section>
   </back>
 </rfc>

--- a/draft-ietf-tls-wkech.xml
+++ b/draft-ietf-tls-wkech.xml
@@ -281,7 +281,7 @@ Client <----------->|                    | facing
     but with the following differences: but with the following differences:
     <ol>
         <li>
-            The client-facing server, (CDS), is a load-balancer and
+            The client-facing server, (CFS), is a load-balancer and
             only does ECH decryption. The load-balancer is
             called cfs.lb.example.
         </li>

--- a/draft-ietf-tls-wkech.xml
+++ b/draft-ietf-tls-wkech.xml
@@ -248,7 +248,7 @@ Client <----------->|                    | facing
                     |                    |
      TLS            |   2001:DB8::1111   |
     Client <-->     |backend.example.com |
-                    |   cfs.cdn.example  |
+                    |     cfs.example    |
                     +--------------------+
                         ^            ^
      (3) ZF reads       |            |  (4) ZF checks
@@ -270,7 +270,7 @@ Client <----------->|                    | facing
 
 <t>
     In this topology, the overall process is as in the previous section,
-    but with the following differences: 
+    but with the following differences: but with the following differences:
     <ol>
         <li>ECH split-mode is supported by the CDN.</li>
         <li>
@@ -287,7 +287,7 @@ Client <----------->|                    | facing
         </li>
         <li>
             backend.example.com content is hosted on some machine(s)
-            accessible via the client-facing servers and the via the VPN.
+            accessible via the client-facing servers and via the VPN.
         </li>
         <li>
             backend.example.com has to acquire the ECH config
@@ -296,15 +296,17 @@ Client <----------->|                    | facing
             https://cfs.cds.example/.well-known/origin-svcb
         </li>
         <li>
-            backend.example.com then publishes it's chosen JSON
+            backend.example.com then publishes its chosen JSON
             (presumably including the relevant ECH config information)
             at https://backend.example.com/.well-known/origin-svcb
-            That resource is hosted on the "real" backend.example.com 
+            That resource is hosted on the "real" backend.example.com
             machine.
+        </li>
         <li>
-            The ZF attempts to connect to the backend using the 
-            published IP address, using the relevant ECH values and confirms
-            that all is working.
+            The ZF attempts to connect to https://backend.example.com using
+            the generated HTTPS record(s), including the
+            relevant ECH values, and confirms that all is
+            working before updating the zone.
         </li>
         <li>
             Note that the ZF is not aware that ECH split-mode is in use.

--- a/draft-ietf-tls-wkech.xml
+++ b/draft-ietf-tls-wkech.xml
@@ -255,8 +255,8 @@ Client <----------->|                    | facing
                     +--------------------+
                     |                    |
      TLS            |   2001:DB8::1111   |
-    Client <-->     |backend.example.com |
-                    |     cfs.example    |
+     Client <---->  |backend.example.com |
+                    |   cfs.lb.example   |
                     +--------------------+
                         ^            ^
      (3) ZF reads       |            |  (4) ZF checks
@@ -280,10 +280,10 @@ Client <----------->|                    | facing
     In this topology, the overall process is as in the previous section,
     but with the following differences: but with the following differences:
     <ol>
-        <li>ECH split-mode is supported by the CDN.</li>
         <li>
-            The client-facing server, e.g. in a CDN, for the backend
-            server only does ECH decryption.
+            The client-facing server, (CDS), is a load-balancer and
+            only does ECH decryption. The load-balancer is
+            called cfs.lb.example.
         </li>
         <li>
             Traffic between the CFS and backend is protected using
@@ -291,17 +291,17 @@ Client <----------->|                    | facing
         </li>
         <li>
             The A/AAAA values for backend.example.com and
-            cfs.cdn.example are the same.
+            cfs.lb.example are the same.
         </li>
         <li>
             backend.example.com content is hosted on some machine(s)
-            accessible via the client-facing servers and via the VPN.
+            accessible via the CFS and via the VPN.
         </li>
         <li>
-            backend.example.com has to acquire the ECH config
+            backend.example.com wants to acquire the ECH config
             information from the CFS by querying the CFS'
             .well-known URL, in this case
-            https://cfs.cds.example/.well-known/origin-svcb
+            https://cfs.lb.example/.well-known/origin-svcb
         </li>
         <li>
             backend.example.com then publishes its chosen JSON

--- a/draft-ietf-tls-wkech.xml
+++ b/draft-ietf-tls-wkech.xml
@@ -230,28 +230,28 @@ Client <----------->|                    | facing
 
         </section>
 
-        <section title="Split-mode, multi-CDN deplpoyment.">
+        <section title="Split-mode deployment.">
 	  <t>
           The following diagram, and this entire section, is a place-holder just
           to have something on which to base discussion, and will change.</t>
-<figure title="Shared-Mode Topology with Zone Factory and DNS" anchor="split-mode"><artwork><![CDATA[
+<figure title="Split-Mode Topology with Zone Factory and DNS" anchor="split-mode"><artwork><![CDATA[
 
                     +--------------------+
                     |        REAL        |
                     | backend.example.com|
                     |                    |
                     +--------------------+
-                        ^^           ^^
-                        ||    VPN    ||
-                        VV           VV
-           +--------------------+ +--------------------+
-           |                    | |                    |
- TLS       |   2001:DB8::1111   | |   2001:DB8::FFFF   | Client-
-Client <-->|backend.example.com | | backend.example.com| facing
-           |  cfs.cdn1.example  | |  cfs.cdn2.example  | servers
-           +--------------------+ +--------------------+
+      (1) backend       ^^           ^^   (2) backend publishes
+          reads CFS'    ||    VPN    ||       backend's
+          .well-known   VV           VV       .well-known
+                    +--------------------+
+                    |                    |
+     TLS            |   2001:DB8::1111   |
+    Client <-->     |backend.example.com |
+                    |   cfs.cdn.example  |
+                    +--------------------+
                         ^            ^
-     (1) ZF reads       |            |  (2) ZF checks
+     (3) ZF reads       |            |  (4) ZF checks
          .well-known    V            V      ECHConfig
                     +--------------------+
                     |                    |
@@ -259,7 +259,7 @@ Client <-->|backend.example.com | | backend.example.com| facing
                     |                    |
                     +--------------------+
                               |
-                              | (3) ZF publishes new HTTPS RR
+                              | (5) ZF publishes new HTTPS RR
                               V
                     +--------------------+
                     |                    |
@@ -268,23 +268,50 @@ Client <-->|backend.example.com | | backend.example.com| facing
                     +--------------------+
 ]]></artwork></figure>
 
-     <t>
-		In this topology, the overall process is as in the previous section,
-		but with the following differences:
-        <ol>
-           <li>There are two client-facing servers (in different CDNs) for the
-               one "REAL" backend server that hosts the actual web resources.</li>
-           <li>ECH split-mode is assumed to be supported by both CDNs.</li>
-           <li>The "REAL" backend.example.com content is hosted on some machine(s)
-               accessible from the client-facing servers via a VPN.</li>
-           <li>The ZF notes that backend.example.com has multiple AAAA RR values
-               published, so queries for the .well-known at each of those. In this
-               case the values received differ.</li>
-	       <li>The ZF next attempts to connect to each CFS using the relevant ECH values and confirms
-	           that they are all working. </li>
-           <li>Note tha the ZF is not aware that ECH split-mode is in use.</li>
-	    </ol>
-     </t>
+<t>
+    In this topology, the overall process is as in the previous section,
+    but with the following differences: 
+    <ol>
+        <li>ECH split-mode is supported by the CDN.</li>
+        <li>
+            The client-facing server, e.g. in a CDN, for the backend
+            server only does ECH decryption.
+        </li>
+        <li>
+            Traffic between the CFS and backend is protected using
+            some kind of VPN.
+        </li>
+        <li>
+            The A/AAAA values for backend.example.com and
+            cfs.cdn.example are the same.
+        </li>
+        <li>
+            backend.example.com content is hosted on some machine(s)
+            accessible via the client-facing servers and the via the VPN.
+        </li>
+        <li>
+            backend.example.com has to acquire the ECH config
+            information from the CFS by querying the CFS'
+            .well-known URL, in this case
+            https://cfs.cds.example/.well-known/origin-svcb
+        </li>
+        <li>
+            backend.example.com then publishes it's chosen JSON
+            (presumably including the relevant ECH config information)
+            at https://backend.example.com/.well-known/origin-svcb
+            That resource is hosted on the "real" backend.example.com 
+            machine.
+        <li>
+            The ZF attempts to connect to the backend using the 
+            published IP address, using the relevant ECH values and confirms
+            that all is working.
+        </li>
+        <li>
+            Note that the ZF is not aware that ECH split-mode is in use.
+        </li>
+    </ol>
+</t>
+
 	 </section>
     </section>
 

--- a/draft-ietf-tls-wkech.xml
+++ b/draft-ietf-tls-wkech.xml
@@ -316,10 +316,12 @@ Client <----------->|                    | facing
             relevant ECH values, and confirms that all is
             working before updating the zone.
         </li>
-        <li>
-            Note that the ZF is not aware that ECH split-mode is in use.
-        </li>
     </ol>
+</t>
+
+<t>
+    Note that the in this example ZF does not necessarily know that ECH
+    split-mode is in use.
 </t>
 
 	 </section>


### PR DESCRIPTION
I tried to simplify and improve the split-mode text. It still needs work for sure, but this might be easier to discuss. We should (later I guess) add back something about multi-CDN deployments.